### PR TITLE
More uniform output

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -13,6 +13,8 @@ show-picked-versions = false
 
 [versions]
 flake8 = 2.5.0
+pytest = 2.8.7
+Sphinx = 1.3.5
 
 [flake8]
 recipe = zc.recipe.egg

--- a/grader/grader/__init__.py
+++ b/grader/grader/__init__.py
@@ -17,6 +17,7 @@ subcommands = OrderedDict([
     ("import", "grader.commands.import"),
     ("list", "grader.commands.list"),
     ("grade", "grader.commands.grade"),
+    ("cat", "grader.commands.cat"),
 ])
 
 

--- a/grader/grader/__init__.py
+++ b/grader/grader/__init__.py
@@ -18,6 +18,7 @@ subcommands = OrderedDict([
     ("list", "grader.commands.list"),
     ("grade", "grader.commands.grade"),
     ("cat", "grader.commands.cat"),
+    ("report", "grader.commands.report"),
 ])
 
 

--- a/grader/grader/commands/cat.py
+++ b/grader/grader/commands/cat.py
@@ -1,0 +1,48 @@
+'''TODO: Cat command docs
+'''
+import logging
+import os
+
+from grader.models import Grader
+from grader.utils.config import require_grader_config
+
+logger = logging.getLogger(__name__)
+
+help = "Print an assignment's grade output to STDOUT"
+
+
+def setup_parser(parser):
+    parser.add_argument('--submission_id', type=str,
+                        help='ID of specific submission to cat.')
+    parser.add_argument('assignment',
+                        help='Name of the assignment.')
+    parser.add_argument('student_id',
+                        help='ID of the student.')
+    parser.set_defaults(run=run)
+
+
+def timestamp(path):
+    return os.stat(path).st_mtime
+
+
+def last_graded(submission):
+    latest_result = max(submission.results_files, key=timestamp)
+    return os.stat(latest_result).st_mtime
+
+
+@require_grader_config
+def run(args):
+    g = Grader(args.path)
+    a = g.get_assignment(args.assignment)
+
+    try:
+        submissions = a.submissions_by_user[args.student_id]
+    except KeyError:
+        logger.error("Cannot find student %s", args.student_id)
+        return
+
+    latest_submission = max(submissions, key=last_graded)
+    latest_result = max(latest_submission.results_files, key=timestamp)
+    logger.debug("Catting %s", latest_result)
+    with open(latest_result) as f:
+        print(f.read())

--- a/grader/grader/commands/cat.py
+++ b/grader/grader/commands/cat.py
@@ -21,13 +21,8 @@ def setup_parser(parser):
     parser.set_defaults(run=run)
 
 
-def timestamp(path):
-    return os.stat(path).st_mtime
-
-
 def last_graded(submission):
-    latest_result = max(submission.results_files, key=timestamp)
-    return os.stat(latest_result).st_mtime
+    return os.stat(submission.latest_result).st_mtime
 
 
 @require_grader_config
@@ -42,7 +37,6 @@ def run(args):
         return
 
     latest_submission = max(submissions, key=last_graded)
-    latest_result = max(latest_submission.results_files, key=timestamp)
-    logger.debug("Catting %s", latest_result)
-    with open(latest_result) as f:
+    logger.debug("Catting %s", latest_submission.latest_result)
+    with open(latest_submission.latest_result) as f:
         print(f.read())

--- a/grader/grader/commands/grade.py
+++ b/grader/grader/commands/grade.py
@@ -11,12 +11,14 @@ help = "Grade assignment submission(s)"
 
 
 def setup_parser(parser):
-    parser.add_argument('--student_id', required=False,
-                        help='Grade submission belonging to this student.')
-    parser.add_argument('--submission_id', required=False,
-                        help='Grade submission with this UUID.')
+    parser.add_argument('--rebuild', action='store_true',
+                        help='Rebuild containers (if they exist).')
+    parser.add_argument('--suppress_output', action='store_false',
+                        help='Don\'t display output.')
     parser.add_argument('assignment',
                         help='Name of the assignment to grade.')
+    parser.add_argument('student_id', nargs='?',
+                        help='Grade submission belonging to this student.')
     parser.set_defaults(run=run)
 
 
@@ -24,7 +26,22 @@ def setup_parser(parser):
 def run(args):
     g = Grader(args.path)
     a = g.get_assignment(args.assignment)
+
+    if args.student_id:
+        try:
+            submissions = a.submissions_by_user[args.student_id]
+        except KeyError:
+            logger.error("Cannot find student %s", args.student_id)
+            return
+
+        for submission in submissions:
+            submission.grade(a, rebuild_container=args.rebuild,
+                             show_output=args.suppress_output)
+        return
+
+    # If we didn't get a student_id
     for user_id, submissions in a.submissions_by_user.items():
         logger.info("Grading submissions for %s", user_id)
         for submission in submissions:
-            submission.grade(a)
+            submission.grade(a, rebuild_container=args.rebuild,
+                             show_output=args.suppress_output)

--- a/grader/grader/commands/grade.py
+++ b/grader/grader/commands/grade.py
@@ -27,20 +27,16 @@ def run(args):
     g = Grader(args.path)
     a = g.get_assignment(args.assignment)
 
+    users = a.submissions_by_user
+
     if args.student_id:
         try:
-            submissions = a.submissions_by_user[args.student_id]
+            users = {args.student_id: users[args.student_id]}
         except KeyError:
             logger.error("Cannot find student %s", args.student_id)
             return
 
-        for submission in submissions:
-            submission.grade(a, rebuild_container=args.rebuild,
-                             show_output=args.suppress_output)
-        return
-
-    # If we didn't get a student_id
-    for user_id, submissions in a.submissions_by_user.items():
+    for user_id, submissions in users.items():
         logger.info("Grading submissions for %s", user_id)
         for submission in submissions:
             submission.grade(a, rebuild_container=args.rebuild,

--- a/grader/grader/commands/list.py
+++ b/grader/grader/commands/list.py
@@ -79,7 +79,7 @@ def build_submission_info(assignments, full=False):
                     ("Last File MTime", str(submission.latest_mtime)),
                     ("Last Commit", str(submission.latest_commit)),
                     ("SHA1", shorten(submission.sha1sum, full=full)),
-                    ("Grade", "--"),
+                    ("Re-Grades", len(submission.results_files)),
                     ("Failed", "--"),
                 ]))
     return info
@@ -100,7 +100,7 @@ def run(args):
     if args.submissions:
         columns = [
             "Assignment", "User ID", "Submission UUID", "Import Time",
-            "Last File MTime", "Last Commit", "SHA1", "Grade", "Failed"
+            "Last File MTime", "Last Commit", "SHA1", "Re-Grades", "Failed"
         ]
         rows = s_info
         rows = sort_by_assignment(rows, args.sortby)

--- a/grader/grader/commands/report.py
+++ b/grader/grader/commands/report.py
@@ -1,0 +1,86 @@
+'''TODO: Report command docs
+'''
+import itertools
+import jinja2
+import logging
+import os
+import yaml
+
+from grader.models import Grader
+from grader.utils.config import require_grader_config
+
+logger = logging.getLogger(__name__)
+
+help = "Generate reports using a gradesheet template"
+
+
+def setup_parser(parser):
+    parser.add_argument('--template', type=str, default="markdown",
+                        help='Type of template to use')
+    parser.add_argument('assignment',
+                        help='Name of the assignment.')
+    parser.add_argument('student_id', nargs='?',
+                        help='ID of student to generate report for.')
+    parser.set_defaults(run=run)
+
+
+def load_data(content):
+    try:
+        return yaml.load(content)
+    except yaml.YAMLError:
+        logger.info(
+            "Couldn't parse YAML for user_id."
+            " Passing to template as 'data'"
+        )
+        return {'data': content}
+
+
+@require_grader_config
+def run(args):
+    g = Grader(args.path)
+    a = g.get_assignment(args.assignment)
+
+    if not a.gradesheet.templates:
+        logger.critical("No available templates in gradesheet.")
+        return
+
+    # Find and load the Jinja2 template
+    template = None
+    try:
+        with open(a.gradesheet.templates[args.template]) as template_file:
+            template = jinja2.Template(template_file.read())
+    except KeyError:
+        logger.error("Couldn't find '%s' template", args.template)
+        return
+
+    # Narrow down users, if necessary
+    users = a.submissions_by_user
+    if args.student_id:
+        try:
+            users = {args.student_id: users[args.student_id]}
+        except KeyError:
+            logger.error("Cannot find student %s", args.student_id)
+            return
+
+    # Make a unique directory for the output
+    output_dir = os.path.join(args.path, args.template)
+    for i in itertools.count(1):
+        if os.path.exists(output_dir):
+            template_name = "{}.{}".format(args.template, i)
+            output_dir = os.path.join(args.path, template_name)
+        else:
+            os.makedirs(output_dir)
+            break
+
+    # Generate reports
+    for user_id, submissions in users.items():
+        logger.info("Generating report for %s", user_id)
+        for submission in submissions:
+            # Load the report data
+            with open(submission.latest_result) as result_file:
+                data = load_data(result_file.read())
+
+            # Save it to a file
+            filename = "{}.{}".format(submission.full_id, args.template)
+            with open(os.path.join(output_dir, filename), 'w') as outfile:
+                outfile.write(template.render(data))

--- a/grader/grader/commands/report.py
+++ b/grader/grader/commands/report.py
@@ -79,6 +79,15 @@ def run(args):
             # Load the report data
             with open(submission.latest_result) as result_file:
                 data = load_data(result_file.read())
+                data.update({
+                    'student': {
+                        'id': user_id,
+                        'name': submission.student_name
+                    },
+                    'assignment': {
+                        'name': submission.assignment.name
+                    }
+                })
 
             # Save it to a file
             filename = "{}.{}".format(submission.full_id, args.template)

--- a/grader/grader/models/config.py
+++ b/grader/grader/models/config.py
@@ -156,6 +156,14 @@ class GraderConfig(Config):
     }
     """The schema for a Grader-wide configuration file"""
 
+    @property
+    def roster(self):
+        return self.data.get('roster', [])
+
+    def get_student_name(self, student_id):
+        d = {x['id']: x['name'] for x in self.roster}
+        return d[student_id]
+
 
 class AssignmentConfig(Config):
     """A class for creating, loading, and accessing assignment-specific,

--- a/grader/grader/models/gradesheet.py
+++ b/grader/grader/models/gradesheet.py
@@ -1,4 +1,5 @@
 import git
+import glob
 import logging
 import os
 
@@ -91,6 +92,13 @@ class GradeSheet(object):
     def dockerfile_path(self):
         """The path to this gradesheet's Dockerfile"""
         return os.path.join(self.path, "Dockerfile")
+
+    @property
+    def templates(self):
+        """A dictionary of this gradesheet's optional report templates"""
+        templates = glob.glob(os.path.join(self.path, '*.template'))
+        return {os.path.basename(t).split('.')[0].lower(): t
+                for t in templates}
 
     def __init__(self, assignment):
         """Instantiates a GradeSheet.

--- a/grader/grader/models/submission.py
+++ b/grader/grader/models/submission.py
@@ -475,6 +475,17 @@ class Submission(DockerClientMixin):
             "submission_uuid": self.uuid,
         }
 
+    @property
+    def results_files(self):
+        """A list of paths to grading results for this submission.
+
+        """
+        name_re = re.compile(r"^{}(?:\..*)$".format(self.user_id))
+        results_dir = self.assignment.results_dir
+        return [os.path.join(results_dir, r)
+                for r in os.listdir(results_dir) if name_re.match(r)]
+
+
     def __init__(self, assignment, tar_name):
         """Instantiates a new Submission.
 

--- a/grader/grader/models/submission.py
+++ b/grader/grader/models/submission.py
@@ -485,6 +485,19 @@ class Submission(DockerClientMixin):
         return [os.path.join(results_dir, r)
                 for r in os.listdir(results_dir) if name_re.match(r)]
 
+    @property
+    def latest_result(self):
+        """Path to the latest result for this submission. If there are no
+        results, returns None.
+
+        """
+        def timestamp(path):
+            return os.stat(path).st_mtime
+
+        results = self.results_files
+        if results:
+            return max(results, key=timestamp)
+        return None
 
     def __init__(self, assignment, tar_name):
         """Instantiates a new Submission.

--- a/grader/grader/models/submission.py
+++ b/grader/grader/models/submission.py
@@ -511,6 +511,7 @@ class Submission(DockerClientMixin):
         """
         self.path = os.path.join(assignment.submissions_dir, tar_name)
         self.assignment = assignment
+        self.grader = assignment.grader
 
         if not os.path.isfile(self.path):
             logger.debug("Cannot find %s", self.path)
@@ -522,6 +523,7 @@ class Submission(DockerClientMixin):
         self.basename = os.path.basename(self.path)
         self.full_id = self.__class__._remove_extension(self.basename)
         self.user_id, self.uuid = self.split_full_id(self.full_id)
+        self.student_name = self.grader.config.get_student_name(self.user_id)
 
     def __str__(self):
         """String representation of a Submission"""

--- a/grader/grader/models/submission.py
+++ b/grader/grader/models/submission.py
@@ -611,19 +611,21 @@ class Submission(DockerClientMixin):
 
         return tmpdir
 
-    def grade(self, assignment, show_output=True):
+    def grade(self, assignment, rebuild_container=False, show_output=True):
         """Performs the magic--- prepares the docker container,
         runs the grade command, and writes to logs.
 
         :param Assignment assignment: The assignment we're grading, used for
             results directory.
+        :param bool rebuild_container: Whether to discard the old
+            container and build a new one instead. Defaults to False.
         :param bool show_output: Whether to output STDOUT/STDERR from the
             container to STDOUT. Defaults to True.
 
         :return: None
 
         """
-        c_id = self.get_container_id()
+        c_id = self.get_container_id(rebuild=rebuild_container)
         logger.debug("Got container ID %s", c_id)
 
         # Start the container

--- a/grader/setup.py
+++ b/grader/setup.py
@@ -14,7 +14,8 @@ setup(  # pragma: no cover
         'PyYAML==3.11',
         'jsonschema==2.5.1',
         'prettytable==0.7.2',
-        'colorlog',
+        'colorlog==2.6.0',
+        'Jinja2==2.8'
     ],
     entry_points={
         'console_scripts': ['grader = grader:run'],


### PR DESCRIPTION
A few things:

* Attempt to save to YAML file (i.e., use `yml` extension) if possible
* Don't overwrite existing grade output
    * Number them `<id>.<num>.<extension>`
    * For example, fmm000.01.log
* Show number of re-grades in `grader list`
    * The number of times you ran `grader grade` for a particular user
* Allow a user to rebuild a container when grading 
    * Delete the old old
* Allow a user to suppress `grader` output during a grade
* Add a `grade cat` command, to print a student's latest submission to `stdout`
* Allow a user to grade for a specific user, based on their id.
